### PR TITLE
Further rustls 0.20 fixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rustls = "0.20"
 
 [dev-dependencies]
 webpki = "0.21"
+rustls-pemfile = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,15 +46,7 @@ impl io::Read for ReadHalf {
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         }
 
-        match connection.reader().read(buf) {
-            Ok(0) => Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "TLS connection closed improperly",
-            )),
-            ok @ Ok(_) => ok,
-            Err(ref e) if e.kind() == io::ErrorKind::ConnectionAborted => Ok(0),
-            err @ Err(_) => err,
-        }
+        connection.reader().read(buf)
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,10 +1,12 @@
 use std::{
+    convert::TryInto,
     io::{BufRead, BufReader, Cursor, Read, Write},
     net::{Shutdown, TcpListener, TcpStream},
     sync::Arc,
 };
 
-use rustls::Session;
+use rustls::Connection;
+use rustls_pemfile;
 
 fn make_tcp_pair() -> (TcpStream, TcpStream) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -16,23 +18,31 @@ fn make_tcp_pair() -> (TcpStream, TcpStream) {
 
 fn read_key() -> rustls::PrivateKey {
     let mut cursor = Cursor::new(include_bytes!("key.pem"));
-    rustls::internal::pemfile::rsa_private_keys(&mut cursor).unwrap()[0].clone()
+    rustls::PrivateKey(rustls_pemfile::rsa_private_keys(&mut cursor).unwrap()[0].clone())
 }
 
 fn read_cert() -> rustls::Certificate {
     let mut cursor = Cursor::new(include_bytes!("cert.pem"));
-    rustls::internal::pemfile::certs(&mut cursor).unwrap()[0].clone()
+    rustls::Certificate(rustls_pemfile::certs(&mut cursor).unwrap()[0].clone())
 }
 
 fn make_client_cfg() -> Arc<rustls::ClientConfig> {
-    let mut cfg = rustls::ClientConfig::new();
-    cfg.root_store.add(&read_cert()).unwrap();
+    let cfg = rustls::ClientConfig::builder()
+        .with_safe_defaults()
+        .with_root_certificates({
+            let mut store = rustls::RootCertStore::empty();
+            store.add(&read_cert()).unwrap();
+            store
+        })
+        .with_no_client_auth();
     Arc::new(cfg)
 }
 
 fn make_server_cfg() -> Arc<rustls::ServerConfig> {
-    let mut cfg = rustls::ServerConfig::new(rustls::NoClientAuth::new());
-    cfg.set_single_cert(vec![read_cert()], read_key()).unwrap();
+    let cfg = rustls::ServerConfig::builder()
+        .with_safe_defaults()
+        .with_no_client_auth()
+        .with_single_cert(vec![read_cert()], read_key()).unwrap();
     Arc::new(cfg)
 }
 
@@ -49,8 +59,8 @@ fn e2e() {
         .name("server".into())
         .spawn(move || {
             let server_cfg = make_server_cfg();
-            let mut session = rustls::ServerSession::new(&server_cfg);
-            session.complete_io(&mut server_stream).unwrap();
+            let mut conn = rustls::ServerConnection::new(server_cfg).unwrap();
+            conn.complete_io(&mut server_stream).unwrap();
 
             let mut server_buf_reader = BufReader::new(server_stream);
             server_buf_reader.fill_buf().unwrap();
@@ -60,26 +70,27 @@ fn e2e() {
 
             let (mut read_half, mut write_half) = rustls_split::split(
                 server_stream,
-                session,
+                Connection::Server(conn),
                 rustls_split::BufCfg::with_data(buf, BUF_SIZE),
                 rustls_split::BufCfg::with_capacity(BUF_SIZE),
             );
 
             let bytes_copied = std::io::copy(&mut read_half, &mut write_half).unwrap();
+
             assert_eq!(bytes_copied, ITERS * MSG.len() as u64);
             write_half.shutdown(Shutdown::Write).unwrap();
         })
         .unwrap();
 
     let client_cfg = make_client_cfg();
-    let dns = webpki::DNSNameRef::try_from_ascii_str("localhost").unwrap();
-    let mut session = rustls::ClientSession::new(&client_cfg, dns);
+    let dns = "localhost".try_into().unwrap();
+    let mut conn = rustls::ClientConnection::new(client_cfg, dns).unwrap();
 
-    session.complete_io(&mut client_stream).unwrap();
+    conn.complete_io(&mut client_stream).unwrap();
 
     let (mut read_half, mut write_half) = rustls_split::split(
         client_stream,
-        session,
+        Connection::Client(conn),
         rustls_split::BufCfg::with_capacity(BUF_SIZE),
         rustls_split::BufCfg::with_capacity(BUF_SIZE),
     );


### PR DESCRIPTION
I completely neglected the tests. While fixing the tests, I noticed a behaviour change in rustls's Read implementation that also needs to be taken into account to make the tests pass.

I already bumped the version number in Cargo.toml to 0.3.0 in the previous PR, and created a tag for it. However, I haven't published the crate yet. After merging this PR, I plan to move the tag, and publish the crate, as version 0.3.0.